### PR TITLE
Suppress warnings on unaltered variables

### DIFF
--- a/Core/Source/InAppPurchaseReceipt.swift
+++ b/Core/Source/InAppPurchaseReceipt.swift
@@ -116,7 +116,7 @@ import DTFoundation
             throw ReceiptParsingError.invalidRootObject
         }
         
-        for var item in rootArray
+        for item in rootArray
         {
             guard item.count == 3,
                 let type = (item[0] as? NSNumber)?.intValue,

--- a/Core/Source/Receipt.swift
+++ b/Core/Source/Receipt.swift
@@ -130,7 +130,7 @@ An iTunes store sales receipt.
             throw ReceiptParsingError.invalidRootObject
         }
         
-        for var element in rootArray
+        for element in rootArray
         {
             guard element.count == 3,
                 let type = (element[0] as? NSNumber)?.intValue,


### PR DESCRIPTION
Two `for` loops prepend unneeded `var` keywords. Remove them to suppress Xcode warnings.