### PR TITLE
Enable macOS spec compliance

### DIFF
--- a/Kvitto.podspec
+++ b/Kvitto.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |spec|
   spec.social_media_url = 'https://twitter.com/cocoanetics'
   spec.source       = { :git => "https://github.com/Cocoanetics/Kvitto.git", :tag => spec.version.to_s }
   spec.ios.deployment_target = '9.0'
+  spec.osx.deployment_target = '10.11'
   spec.license      = 'BSD'
   spec.requires_arc = true
   spec.dependency 'DTFoundation/DTASN1', '~> 1.7.13'
@@ -15,6 +16,7 @@ Pod::Spec.new do |spec|
 
   spec.subspec 'Core' do |ss|
     ss.ios.deployment_target = '9.0'
+    ss.osx.deployment_target = '10.11'
     ss.source_files = 'Core/Source/*.{h,m,c,swift}'
   end
 end


### PR DESCRIPTION
Unless there's any reason to explicitly exclude it.